### PR TITLE
Highlights, dummy icons and tips

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
     directory: "/acsense-tcd" # Location of package manifests
     target-branch: "dev" # Branch to create pull requests against (optional, defaults to default branch)
     schedule:
-      interval: "weekly"
+      interval: "monthly"

--- a/acsense-tcd/components/OverworldMap.client.vue
+++ b/acsense-tcd/components/OverworldMap.client.vue
@@ -29,6 +29,11 @@ export default {
             type: Object,
             default: () => {}
         },
+
+        dummy_studentSpaces: {
+            type: Array,
+            default: () => []
+        },
     },
     data() {
         return {
@@ -547,6 +552,33 @@ export default {
                 }
             });
 
+            // Repeat for the dummy spaces, but without any interaction
+            this.dummy_studentSpaces.forEach(area => {
+
+                // Figure out what the icon will be by matching the area type to the area type in the area_types array
+                let icon_url = area_types.find(area_type => area_type.category == area.type).icon;
+                let styled_label = area_types.find(area_type => area_type.category == area.type).styled_label;
+
+                // Create the icon object
+                // The className is used to make the icon fade in and out when the zoom changes
+                let myIcon = L.icon({
+                    iconUrl: icon_url, 
+                    iconSize: [50, 50], 
+                    className: "sense-icon",
+                });
+
+                // Create the marker object, pushing the click through to the building behind
+                let marker = L.marker(area.location, {
+                    icon: myIcon, 
+                    alt: area.name,
+                    interactive: false,
+                });
+
+                if (styled_label in areas_sorted){
+                    areas_sorted[styled_label].push(marker);
+                }
+            });
+
             let areas_grouped = [];
 
             // Now transform the arrays into layer group objects
@@ -570,6 +602,10 @@ export default {
             // Add the popups to the student spaces
             // this.addPopupsToStudentSpaces(areas_sorted);
         },
+
+        // Allows for icons to be placed on the map without a corresponding student space
+        // For decorative purposes
+        addDummyStudentSpaces(){},
 
         // TODO: Add popups to student spaces
         addPopupsToStudentSpaces(areas){
@@ -648,7 +684,7 @@ export default {
 
         info.addTo(this.map);
         search.addTo(this.map);
-},
+        },
 
         // Add the overworld fast travel jump arrows to the map
         addJumpArrows(){

--- a/acsense-tcd/components/OverworldMap.client.vue
+++ b/acsense-tcd/components/OverworldMap.client.vue
@@ -110,29 +110,63 @@ export default {
             this.addControlButtons();
 
             // Check if there's a building in the URL, and if so, fly to it
-            this.checkForBuildingInURL();
+            this.checkForBuildingOrSpaceInURL();
         },
 
-        checkForBuildingInURL(){
+        checkForBuildingOrSpaceInURL(){
 
             // Check if there's a building in the URL, and if so, fly to it
             let url = window.location.href;
+            const urlParams = new URL(url).searchParams;
+
+            // Initialise check variable
+            let buildingMatches = false;
+
+            // First, check if there's a highlight parameter in the URL
+            // if there isn't, we don't need to check any further
+            if (!url.includes("highlight")) return;
+
+            // Else, find the highlight parameter
+            const highlight = urlParams.get('highlight');
             
+            // if (highlight == feature.properties.canonical){
+
             // Loop through the buildings and check if the url contains the canonical name
+            // Run buildings first, because if a building and a space share a canonical name, the building will be prioritised
+            // Zooming to the building will also zoom to the space, so it's not a problem
             this.buildings.forEach(building => {
-                if (window.location.href.includes(building.canonical)){
+                if (highlight == building.canonical){
                     
                     // Dismiss the modals if they're open
-                    this.$emit('dismissModals');
+                    // this.$emit('dismissModals');
 
                     // Get the center of the building to aim for
                     let center = this.getGeometricCenter(building.geometry.coordinates);
 
                     // Fly to the building at the correct zoom level
                     this.map.flyTo(center, this.LABEL_PRIMARY_RANGE_UPPER + 0.5);
+
+                    buildingMatches = true;
                     
                 }
             });
+            
+            // If a building was found, don't check for a space
+            if (buildingMatches) return;
+            
+            // Loop through the student spaces and check if the url contains the canonical name
+            this.studentSpaces.forEach(space => {
+                if (highlight == space.canonical){
+                    
+                    // Dismiss the modals if they're open
+                    // this.$emit('dismissModals');
+
+                    // Fly to the building at the correct zoom level
+                    this.map.flyTo(space.location, this.LABEL_PRIMARY_RANGE_UPPER + 0.5);
+                    
+                }
+            });
+
         },
 
         // Add the overlays to the map eg main campus
@@ -411,7 +445,10 @@ export default {
             }
 
             // Check the url for the building canonical, in which case we want to highlight it
-            if (window.location.href.includes(feature.properties.canonical)){
+            const urlParams = new URL(window.location.href).searchParams;
+            const highlight = urlParams.get('highlight');
+            
+            if (highlight == feature.properties.canonical){
 
                 return {
                     fillColor: "#E53397",
@@ -464,6 +501,7 @@ export default {
             this.studentSpaces.forEach(area => {
 
                 // Figure out what the icon will be by matching the area type to the area type in the area_types array
+                // TODO: Replace with composable for finding the icon that includes icon_override
                 let icon_url = area_types.find(area_type => area_type.category == area.type).icon;
                 let styled_label = area_types.find(area_type => area_type.category == area.type).styled_label;
 
@@ -472,8 +510,23 @@ export default {
                 let myIcon = L.icon({
                     iconUrl: icon_url, 
                     iconSize: [50, 50], 
-                    className: "sense-icon"
+                    className: "sense-icon",
                 });
+
+                // If the url contains the canonical name of the area, overwrite the icon with the highlighted version
+                const urlParams = new URL(window.location.href).searchParams;
+                const highlight = urlParams.get('highlight');
+                
+                if (highlight == area.canonical){
+                    myIcon = L.icon({
+                        iconUrl: icon_url, 
+                        iconSize: [50, 50], 
+                        className: "sense-icon",
+                        shadowUrl: '/images/red-dot.png',
+                        shadowSize: [60, 60],
+                        // shadowAnchor: [22, 94]
+                    });
+                }
 
                 // Create the marker object
                 let marker = L.marker(area.location, {icon: myIcon, alt: area.name});

--- a/acsense-tcd/components/info/AccessTips.vue
+++ b/acsense-tcd/components/info/AccessTips.vue
@@ -4,7 +4,7 @@
     <div class="card-header">
         <h6 class="m-0">
             <strong>Access Tips | </strong>
-            <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=jb6V1Qaz9EWAZJ5bgvvlK8Q61F2uS1FIukiAqksty_1UNTBEMFQ2MU5JUEpSUThIRjMyUExZSU1QMSQlQCN0PWcu" target="_blank" class="small"> Submit a tip</a>
+            <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=jb6V1Qaz9EWAZJ5bgvvlK19m7VaqSzBAqvP3e08WnHFUMkVaUjkyWEc5WTNWMDY3OThNOU9ERVZRNS4u" target="_blank" class="small"> Submit a tip</a>
         </h6>
     </div>
     <div class="card-body">

--- a/acsense-tcd/components/info/AccessTips.vue
+++ b/acsense-tcd/components/info/AccessTips.vue
@@ -8,13 +8,16 @@
         </h6>
     </div>
     <div class="card-body">
-        <ul class="list-group list-group-flush">
+        <!-- If there are tips, display them -->
+        <ul v-if="tips.length > 0" class="list-group list-group-flush">
             <li 
             v-for="tip in tips" 
             class="list-group-item">
                 {{ tip }}
             </li>
         </ul>
+        <!-- Otherwise, Invite some -->
+        <span v-else><em>This {{entity}} has no tips! Why don't you submit one?</em></span>
     </div>
 </div>
 
@@ -26,6 +29,10 @@ export default {
     props: {
         tips : {
             type: Array as () => string[],
+            required: true,
+        },
+        entity : {
+            type: String,
             required: true,
         }
     }

--- a/acsense-tcd/pages/index.vue
+++ b/acsense-tcd/pages/index.vue
@@ -6,6 +6,7 @@
     :buildings="buildings"
     :studentSpaces="studentSpaces"
     :spaceStyles="spaceStyles"
+    :dummy_studentSpaces="dummy_studentSpaces"
     @openBuildingModal="openBuildingModal"
     @openSpaceModal="openSpaceModal"
     @openLegendModal="legendModalOpen = true"
@@ -158,6 +159,8 @@ import { createClient } from '@supabase/supabase-js';
     let spaceStyles = ref([]);
     let welcome = ref({});
 
+    let dummy_studentSpaces = ref([]);
+
 
     // Flyovers
     const { data: flyovers_data, error: flyover_error} = await supabase
@@ -198,6 +201,19 @@ import { createClient } from '@supabase/supabase-js';
     }
     else {
         studentSpaces = ref(studentSpaces_data);
+    }
+
+    // Dummy Student Spaces
+    const { data: dummy_studentSpaces_data, error: dummy_studentSpace_error} = await supabase
+        .from('space_dummy')
+        .select('*')
+
+    if (studentSpace_error) {
+        console.log('An error occured while fetching dummy student spaces:');
+        console.log(studentSpace_error);
+    }
+    else {
+        dummy_studentSpaces = ref(dummy_studentSpaces_data);
     }
 
     // Overlays

--- a/acsense-tcd/pages/index.vue
+++ b/acsense-tcd/pages/index.vue
@@ -83,11 +83,10 @@
                 </div>
                 
                 <div class="modal-footer d-flex justify-content-between">
-                    <div class="form-check">
-                        <input class="form-check-input" type="checkbox" :value="skipWelcome" id="skipWelcomeCheck" @change="setWelcomeSkipCookie"
-                        title="This checkbox stores a non-tracking cookie on your device, to store your preference">
+                    <div class="form-check" title="This checkbox stores a non-tracking cookie on your device, to store your preference">
+                        <input class="form-check-input" type="checkbox" v-model="skipWelcome" id="skipWelcomeCheck">
                         <label class="form-check-label" for="skipWelcomeCheck">
-                            Don't show again
+                            Don't show again (stores a cookie)
                         </label>
                     </div>
                     <button type="button" class="btn btn-primary" data-bs-dismiss="modal" @click="welcomeModalOpen=false; legendModalOpen=true">Close</button>
@@ -277,6 +276,11 @@ export default {
         // Check if the user has indicated they want to skip the welcome modal
         this.checkSkipWelcome();
     },
+    watch: {
+        skipWelcome: function(){
+            this.setWelcomeSkipCookie();
+        }
+    },
 
     methods: {
 
@@ -304,23 +308,42 @@ export default {
         // Check the cookies to see if the user has requested to skip the welcome modal
         checkSkipWelcome(){
             // Access the cookie
-            const skipWelcomeCookie = useCookie('tcdsense-skipWelcome')
-            console.log("Cookie value:", skipWelcomeCookie.value);
+            let skipWelcomeCookie = useCookie('tcdsense-skipWelcome');
 
-            // Check the state, assign it to false if it doesn't exist
-            skipWelcomeCookie.value = skipWelcomeCookie.value || false;
+            // Initialise the cookie if it doesn't exist
+            skipWelcomeCookie.value = skipWelcomeCookie.value || 'false';
 
-            // Open or close the welcome modal based on the cookie value
-            this.welcomeModalOpen = !skipWelcomeCookie.value;
+            // If the cookie exists, and is set to true, skip the welcome modal
+            if (skipWelcomeCookie.value == 'false'){
+                this.welcomeModalOpen = true;
+            }
+
+            // If the cookie was initialised for this check, it'll be non-persistent
             
         },
 
         setWelcomeSkipCookie(){
-            // Access the cookie
-            const skipWelcomeCookie = useCookie('tcdsense-skipWelcome')
+            // create the cookie, if the user has requested to skip the welcome modal
+            if (this.skipWelcome){
+                console.log("creating cookie")
+                // Create the cookie to expire in 6 months
+                let skipWelcomeCookie =  useCookie('tcdsense-skipWelcome', {maxAge: 60*60*24*180});
 
-            // Assign it to true
-            skipWelcomeCookie.value = true;
+                skipWelcomeCookie.value = 'true';
+
+                console.log(skipWelcomeCookie);
+            }
+            else {
+                console.log("deleting cookie")
+                // Delete the cookie by setting it to expire in 10 seconds
+                let skipWelcomeCookie =  useCookie('tcdsense-skipWelcome', {maxAge: 10});
+
+                skipWelcomeCookie.value = 'false';
+
+                console.log(skipWelcomeCookie);
+            }
+            
+
         }
 
     }

--- a/acsense-tcd/pages/info/[buildingId]/index.vue
+++ b/acsense-tcd/pages/info/[buildingId]/index.vue
@@ -35,9 +35,8 @@
             />
         </div>
 
-        <div style="grid-area: tips;"
-        v-if="building.tips.length >0">
-            <AccessTips :tips="building.tips" />
+        <div style="grid-area: tips;">
+            <AccessTips :tips="building.tips" :entity="'building'"/>
             
         </div>
 
@@ -268,7 +267,7 @@ import {createClient} from '@supabase/supabase-js'
         }
         else {
             console.log("Space icons retrieved")
-            console.log(icons)
+            // console.log(icons)
             return JSON.parse(JSON.stringify(icons));
         }
     }

--- a/acsense-tcd/pages/info/[buildingId]/index.vue
+++ b/acsense-tcd/pages/info/[buildingId]/index.vue
@@ -9,7 +9,11 @@
 
             <h1>{{building.display_name}}</h1>
 
-            <p v-if="building.aka" id="aka" style="display:block"><b>Also Known as:</b> {{building.aka}}</p>
+            <p v-if="building.aka" id="aka" class="d-block pb-0 mb-0"><b>Also Known as:</b> {{building.aka}}</p>
+            <!-- Pill link to highlight the building on the map -->
+            <a class="btn badge rounded-pill text-bg-warning text-decoration-none"
+            :href="'/?highlight='+building.canonical">
+            Highlight on map</a>
         </div>
             
         <div id="description" style="grid-area: desc; justify-self: start;">

--- a/acsense-tcd/pages/space/[spaceID].vue
+++ b/acsense-tcd/pages/space/[spaceID].vue
@@ -48,11 +48,10 @@
             <!-- Otherwise, take it's own space -->
             <div 
             :style="!infoBoxDisplays ? 'grid-area: tips;' : 'grid-area: tabs;'"
-            class="my-3"
-            v-if="space.tips.length >0">
-                <AccessTips :tips="space.tips" />
+            class="my-3">
+                <AccessTips :tips="space.tips" :entity="'space'"/>
             </div>
-            <div :style="!infoBoxDisplays ? 'grid-area: tips;' : 'grid-area: tabs;'"
+            <!-- <div :style="!infoBoxDisplays ? 'grid-area: tips;' : 'grid-area: tabs;'"
             class="my-3"
             v-else>
                 <div class="card access-tips-card">
@@ -66,7 +65,7 @@
                         <span> This space has no tips! Why don't you submit one?</span>
                     </div>
                 </div>
-            </div>
+            </div> -->
             
     
             <!-- Infobox -->

--- a/acsense-tcd/pages/space/[spaceID].vue
+++ b/acsense-tcd/pages/space/[spaceID].vue
@@ -6,13 +6,18 @@
     
             <div class="info-page-title" style="grid-area: title;">
                 <h1>{{space.name}}</h1>
-                <p style="display:block">
+                <p v-if="space.aka" id="aka" class="d-block pb-0 mb-0"><b>Also Known as:</b> {{space.aka}}</p>
+                <p class="d-block pb-0 mb-0">
                     <em>{{space.type}}</em> 
                     <span v-if="space.building != null"> 
                         &#8212; 
                         <a :href="'/info/' + space.building"> {{ space.building_display_name }}</a>
                     </span>
                 </p>
+                <!-- Pill link to highlight the building on the map -->
+                <a class="btn badge rounded-pill text-bg-warning text-decoration-none"
+                :href="'/?highlight='+space.canonical">
+                Highlight on map</a>
             </div>
                 
             <div id="description" style="grid-area: desc; justify-self: start;">
@@ -42,12 +47,12 @@
             <!-- If there's no infobox, but there are openingtimes, take up the infobox space -->
             <!-- Otherwise, take it's own space -->
             <div 
-            :style="!infoBoxDisplays && space.opening_times ? 'grid-area: tips;' : 'grid-area: tabs;'"
+            :style="!infoBoxDisplays ? 'grid-area: tips;' : 'grid-area: tabs;'"
             class="my-3"
             v-if="space.tips.length >0">
                 <AccessTips :tips="space.tips" />
             </div>
-            <div style="grid-area: tips;"
+            <div :style="!infoBoxDisplays ? 'grid-area: tips;' : 'grid-area: tabs;'"
             class="my-3"
             v-else>
                 <div class="card access-tips-card">
@@ -76,11 +81,11 @@
             <!-- Timebox -->
             <!-- Displays if there's data to display -->
             <!-- Shows a placeholder message iff there's no data and there's an infobox -->
-            <div style="grid-area: opening-times; justify-self: start; align-self: start;" v-if="space.opening_times">
+            <div style="grid-area: opening-times; justify-self: start; align-self: start;" v-if="timeBoxDisplays">
                 <Timebox
                 :times="space.opening_times"/>
             </div>
-            <div v-if="infoBoxDisplays && !space.opening_times" style="grid-area: opening-times; align-self: center; margin-left: min(3rem, 3vw); margin-right: min(3rem, 3vw);">
+            <div v-if="infoBoxDisplays && !timeBoxDisplays" style="grid-area: opening-times; align-self: center; margin-left: min(3rem, 3vw); margin-right: min(3rem, 3vw);">
                 <div 
                 class="time-card card  pt-2 mx-2 px-3" 
                 style="grid-area: open-times; justify-self: start; align-self: start; margin-left: min(3rem, 3vw); margin-right: min(3rem, 3vw);">
@@ -334,6 +339,11 @@ import {createClient} from '@supabase/supabase-js';
     const infoBoxContent = ref(setInfoBoxContent(space.value));
     // console.log(infoBoxContent);
     const infoBoxDisplays = ref(infoBoxDisplayCheck(infoBoxContent.value));
+    const timeBoxDisplays = ref(
+        space.value.opening_times != null && 
+        (space.value.opening_times.sat.open || space.value.opening_times.holidays.open || space.value.opening_times.weekday.open)
+        // false
+        );
 
     // Set the SEO and page title
 


### PR DESCRIPTION
* Added links to all pages for highlighting the building/space on the map
* Added a dummy_space table that displays decorative (nonclickable) space icons to the map 
* Replaced the "Submit a tip" link
* If a page doesn't have any tips, there's now a suggestion to submit tips rather than just not displaying the section 